### PR TITLE
Simplified Admonition Titles

### DIFF
--- a/docs/meps/mep-admonition-titles.md
+++ b/docs/meps/mep-admonition-titles.md
@@ -1,4 +1,5 @@
 ---
+title: Simplify Named Admonition Syntax
 mep:
   id: <NNNN - Add when this MEP becomes Active>
   created: <yyyy-mm-dd - date MEP is active>
@@ -6,7 +7,7 @@ mep:
     - Rowan Cockett @rowanc1
     - Matt McKay @mmcky
   status: Draft
-  discussion:
+  discussion: https://github.com/executablebooks/myst-enhancement-proposals/pull/12
 ---
 
 # Simplify Named Admonition Syntax


### PR DESCRIPTION
# 📖 [Read the MEP Here](https://myst-eps--12.org.readthedocs.build/en/12/meps/mep-admonition-titles/)

We propose a simplified syntax to allow arguments for all named admonitions. The syntax allows an argument for any title of a named admonition like `{tip}` or `{note}`, to allow users to easily set the color and icon of an admonition while also having a custom title. The proposed syntax is:

````markdown
```{note} Custom Note Title
Body of the styled admonition.
```
````

Coauthored with @mmcky.

See also:
- https://github.com/executablebooks/myst-spec/issues/49

TODO:
- [ ] Merge cross references, turn that to active `MEP0002`!
- [ ] Another pass on the document, cleaning up any ideas
- [ ] Get images into a local folder
- [ ] discuss MEP codemods and how to do this, update that section