### PR TITLE
Add a light PR template for MEPs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,14 @@
+<!-- This is the template for a MEP. If not proposing a MEP delete this and use whatever structure you like. -->
+
+_One sentence description of what this MEP proposes. One sentence description of its impact._
+
+## Authors
+
+<!-- Should be the same authorship as defined in the PR -->
+- _author 1_
+- _author 2_
+
+## Issue
+
+<!-- The issue where this idea was originally introduced and discussed -->
+- _issue link_


### PR DESCRIPTION
This is a simple PR template for MEPs that has specific places for information that is important to guide discussion around the MEP. It's designed to be very lightweight and focused on only the most relevant information, since the MEP itself should be the source of truth for the full context needed to decide on a MEP.

It's inspired by some confusion that was created by not listing authors in the PR body in https://github.com/jupyter-book/myst-enhancement-proposals/pull/28