### PR TITLE
🪐 Per-Output AST Representation for Code Cell Outputs

### DIFF
--- a/meps/mep-0004.md
+++ b/meps/mep-0004.md
@@ -58,6 +58,7 @@ In this structure, a single `Output` node contained an **array** of output data 
 **New Structure (Version 3):**
 
 ```typescript
+// Outputs (below) contains one or more Output nodes
 type Output = {
   type: 'output';
   children: (FlowContent | ListContent | PhrasingContent)[];

--- a/meps/mep-0004.md
+++ b/meps/mep-0004.md
@@ -1,8 +1,8 @@
 ---
 label: MEP0004
-title: Per-Output AST Representation for Code Cell Outputs
-short_title: Per-Output AST
-description: Extend the MyST AST to represent individual code cell outputs as separate AST nodes, enabling output content to participate in MyST builds (e.g., generate and consume reference labels).
+title: Per-Output AST Representation for Code Cells
+short_title: Granular Outputs
+description: Extend the MyST AST to represent individual code-cell outputs as separate AST nodes, enabling output content to participate in MyST builds (e.g., generate and consume reference labels).
 date: 2025/12/04
 authors:
   - agoose77
@@ -23,17 +23,17 @@ We propose extending the MyST AST with a new node type to represent individual c
 
 Code-cells from Jupyter Notebooks can produce rich output like Markdown, LaTeX, and tables. Right now, each output is effectively treated as a <wiki:Black_Box>, which is only interpreted at export time (to PDF, web, etc.) such that static exports and web build are required to interpret the MIME bundle outputs. As a result, the output content does not participate in a MyST build i.e. the Markdown or LaTeX output cannot generate or consume referencing labels.
 
-This limitation prevents programmatic generation of content that integrates with the rest of the document. For example, if a code cell generates Markdown output containing a figure with a label, that label cannot be referenced from other parts of the document, and the figure cannot appear in cross-reference resolution.
+This limitation prevents programmatic generation of content that integrates with the rest of the document. For example, if a code-cell generates Markdown output containing a figure with a label, that label cannot be referenced from other parts of the document, and the figure cannot appear in cross-reference resolution.
 
 ### Use Cases
 
-This enhancement lays the foundation to enable several important use cases (it does not solve for those use-cases now, but is a required step):
+This enhancement lays the foundation to enable several important use cases in future MEPs:
 
-1. **Programmatic Content Generation**: Users can generate MyST Markdown from code cells, and this content can participate fully in the build process, including reference resolution.
+1. **Programmatic Content Generation**: Users can generate MyST Markdown from code-cells and have the MyST Document Engine parse the results.
 
 2. **Integrated Outputs**: Generated Markdown can define and consume reference targets that are visible to the rest of the project, enabling richer integration between computational content and documentation.
 
-3. **Executable Plugins Pattern**: Similar to executable plugins documentation for directives that can return MyST AST by printing to stdout, users should be able to do the same via `{code-cell}` directives and Jupyter Notebook cells. This would allow users to more flexibly generate MyST AST without requiring any kernel-specific libraries (since you'd just be using stdout).
+3. **MyST-aware Kernels**: Libraries running in Jupyter Kernels may output AST via MIME bundles with a MyST-aware MIME type, e.g. `application/vnd.mystmd.ast+json;version=1`. This would enable richer integrations than simple Markdown code generation.
 
 This proposal addresses the requirements described in [#1026](https://github.com/jupyter-book/mystmd/issues/1026), which tracks the need to associate AST subtrees with individual cell outputs.
 
@@ -47,7 +47,7 @@ The MyST AST will be extended to support per-output AST representation through t
 
 ```typescript
 type OutputV2 = {
-  type: 'output';
+  type: "output";
   data?: any[]; // Array of IOutput bundles
   visibility?: any;
 };
@@ -60,14 +60,14 @@ In this structure, a single `Output` node contained an **array** of output data 
 ```typescript
 // Outputs contains one or more Output nodes (below)
 type Outputs = {
-  type: 'outputs';
+  type: "outputs";
   children: (Output | FlowContent | ListContent | PhrasingContent)[]; // Support placeholders in addition to outputs
   visibility?: Visibility; // `show`, `hide`, or `remove`
   scroll?: boolean;
 };
 
 type Output = {
-  type: 'output';
+  type: "output";
   children: (FlowContent | ListContent | PhrasingContent)[];
   jupyter_data: IOutput; // Single IOutput bundle from Jupyter Notebooks
 };
@@ -134,7 +134,10 @@ Existing identifiers for the `Output` / `Outputs` nodes are not modified, as the
     },
     {
       "type": "output",
-      "jupyter_data": { "output_type": "display_data", "data": { "text/markdown": "**Bold**" } },
+      "jupyter_data": {
+        "output_type": "display_data",
+        "data": { "text/markdown": "**Bold**" }
+      },
       "children": []
     }
   ]

--- a/meps/mep-0004.md
+++ b/meps/mep-0004.md
@@ -165,7 +165,7 @@ Upgrading from V2 to V3 is a lossy process if the number of outputs is greater t
 
 Existing content using V2 format can be automatically upgraded during processing (e.g. [#2551](https://github.com/jupyter-book/mystmd/pull/2551)). The downgrade path ensures that tools expecting V2 format can still work with V3 content when needed.
 
-## UX implications & migration
+## UX Implications & Migration
 
 ### Migration Impact
 
@@ -179,9 +179,9 @@ Existing content using V2 format can be automatically upgraded during processing
 
 As a direct consequence of this MEP, themes and renderers will need to be updated to handle the new `Outputs` container node and iterate over `Output` children. However, there are several ways that AST renderers such as web themes and templates can pull in incompatible ASTs:
 
-- New AST renderer provided with old AST content
-- Dynamic loading of new AST in old AST renderers (web only)
-- Dynamic loading of old AST in new AST renderers (web only)
+- New AST renderer provided with old AST content.
+- Dynamic loading of new AST in old AST renderers (web only).
+- Dynamic loading of old AST in new AST renderers (web only).
 
 #### Content-Renderer Separation
 
@@ -193,7 +193,7 @@ Although typical usage of the MyST Document Engine as a static site generator hi
 
 #### Dynamic loading of AST
 
-Outside of deploying AST renderers in a CDN context, it is also possible for MyST Themes to pull in incompatible AST via the external cross-reference (xref) mechanism. This may affect users who build sites with `myst build --site` and deploy them to static web servers like GitHub Pages. Sites that use external xrefs support dynamic fetching of AST, which happens at reading time, _not at page build time_. This means that xrefs may pull in incompatible (future or past) versions of the AST that may fail to render properly. Future work may be done to address AST upgrading and/or AST downgrading in these contexts.
+Outside of deploying AST renderers in a CDN context, it is also possible for MyST Themes to pull in incompatible AST via the external cross-reference (xref) mechanism. This is performed at build time (where it is automatically migrated) and at read-time (where it is presently not). This may affect users who build sites with `myst build --site` and deploy them to static web servers like GitHub Pages. Sites that use external xrefs support dynamic fetching of AST, which happens at reading time, _not at page build time_. This means that xrefs may pull in incompatible (future or past) versions of the AST that may fail to render properly. Future work may be done to address AST upgrading and/or AST downgrading in these contexts.
 
 ## References
 

--- a/meps/mep-0004.md
+++ b/meps/mep-0004.md
@@ -58,18 +58,18 @@ In this structure, a single `Output` node contained an **array** of output data 
 **New Structure (Version 3):**
 
 ```typescript
-// Outputs (below) contains one or more Output nodes
-type Output = {
-  type: 'output';
-  children: (FlowContent | ListContent | PhrasingContent)[];
-  jupyter_data: IOutput; // Single IOutput bundle from Jupyter Notebooks
-};
-
+// Outputs contains one or more Output nodes (below)
 type Outputs = {
   type: 'outputs';
   children: (Output | FlowContent | ListContent | PhrasingContent)[]; // Support placeholders in addition to outputs
   visibility?: Visibility; // `show`, `hide`, or `remove`
   scroll?: boolean;
+};
+
+type Output = {
+  type: 'output';
+  children: (FlowContent | ListContent | PhrasingContent)[];
+  jupyter_data: IOutput; // Single IOutput bundle from Jupyter Notebooks
 };
 ```
 
@@ -82,6 +82,13 @@ The key changes are:
 3. Each `Output` child can have its own AST subtree, enabling per-output parsing and reference resolution.
 
 ### Migration Strategy
+
+The version migration is handled through upgrade and downgrade functions that transform between V2 and V3 representations. The migration preserves:
+
+- Identifiers (`id`, `label`, `identifier`, `html_id`)
+- Target properties
+- Placeholder nodes
+- Visibility settings
 
 Existing identifiers for the `Output` / `Outputs` nodes are not modified, as these are considered "content". The migration path includes:
 
@@ -128,65 +135,15 @@ Existing identifiers for the `Output` / `Outputs` nodes are not modified, as the
     {
       "type": "output",
       "jupyter_data": { "output_type": "display_data", "data": { "text/markdown": "**Bold**" } },
-      "children": [
-        {
-          "type": "strong",
-          "children": [{ "type": "text", "value": "Bold" }]
-        }
-      ]
+      "children": []
     }
   ]
 }
 ```
 
-## Examples
-
-### Markdown Output with References
-
-With this change, a code cell can generate Markdown output that defines and references labels:
-
-```python
-# Generate MyST content with a figure reference
-markdown_output = """
-Here is a reference to [](#fig:my-figure).
-
-:::{figure} images/plot.png
-:name: fig:my-figure
-
-My generated plot.
-:::
-"""
-
-from IPython.display import display
-display({
-  "text/markdown": markdown_output,
-}, raw=True)
-```
-
-The Markdown output can now be parsed and integrated into the document's reference resolution system.
-
-### Multiple Outputs with Individual ASTs
-
-A code cell that produces multiple outputs, each with its own parsed content:
-
-```python
-print("First output stream")
-display({"text/markdown": "**Second** output"}, raw=True)
-display({"text/latex": "$$E = mc^2$$"}, raw=True)
-```
-
-Each of these outputs will be represented as a separate `Output` node with its own AST subtree.
+The `text/markdown` output may be parsed into native `children` nodes in native MyST AST, however, that is out of scope for this proposal.
 
 ## Implementation Details
-
-### Version Migration
-
-The version migration is handled through upgrade and downgrade functions that transform between V2 and V3 representations. The migration preserves:
-
-- Identifiers (`id`, `label`, `identifier`, `html_id`)
-- Target properties
-- Placeholder nodes
-- Visibility settings
 
 ### Parsing Output Content
 
@@ -199,19 +156,9 @@ When output content is parsed (e.g., Markdown or LaTeX from MIME bundles), the r
 
 ### Backward Compatibility
 
-Existing content using V2 format will be automatically upgraded during processing. The downgrade path ensures that tools expecting V2 format can still work with V3 content when needed.
+Existing content using V2 format can be automatically upgraded during processing (e.g. [#2551](https://github.com/jupyter-book/mystmd/pull/2551)). The downgrade path ensures that tools expecting V2 format can still work with V3 content when needed.
 
 ## UX implications & migration
-
-### Benefits
-
-1. **Seamless Integration**: Code-generated content can now participate fully in MyST builds without special handling.
-
-2. **Better Cross-Referencing**: Generated figures, equations, and sections can be referenced from anywhere in the document.
-
-3. **Flexible Generation**: Users can generate MyST content programmatically using any Jupyter kernel without kernel-specific libraries.
-
-4. **Consistent Behavior**: Output parsing follows the same rules and capabilities as the rest of the document.
 
 ### Migration Impact
 
@@ -223,39 +170,7 @@ Existing content using V2 format will be automatically upgraded during processin
 
 ### Theme Considerations
 
-Themes and renderers will need to be updated to handle the new `Outputs` container node and iterate over `Output` children. However, the rendering output should remain consistent, as the logical grouping of outputs is preserved.
-
-## Definition of Done
-
-- Individual `IOutput` objects are represented in the AST as individual AST trees
-- Each `Output` node can carry its own AST subtree in `children`
-- `Outputs` node container has 1:1 correspondence between `Output` children and `IOutput` bundles
-- Version migration functions (upgrade/downgrade) correctly transform between V2 and V3
-- Generated Markdown in code cells can define and consume reference targets visible to the rest of the project
-- Generated Markdown appears correctly in PDF builds with proper cross-referencing
-- Multiple outputs from a single cell are correctly represented as separate `Output` nodes
-- Themes correctly render the new AST structure
-- In-browser execution via Thebe continues to work with the new structure
-
-## Questions or Objections
-
-### Kernel Support
-
-**Question**: Does this require all kernels to implement the display protocol?
-
-**Response**: All Jupyter kernels should implement the display protocol as part of the Jupyter message protocol. For kernels that don't support direct AST output, users can output Markdown or other MIME types that will be parsed into AST during the build process.
-
-### Performance Considerations
-
-**Question**: Will parsing outputs for every code cell impact build performance?
-
-**Response**: Output parsing will only occur when outputs contain parseable content (e.g., Markdown, LaTeX). Plain text or binary outputs will not trigger parsing. The performance impact should be minimal and only occur when the feature is actively used.
-
-### AST Versioning
-
-**Question**: How does this interact with other AST versioning?
-
-**Response**: This change introduces a new AST version (V3) for output nodes specifically. The migration functions ensure compatibility with existing V2 content. This is consistent with the MyST AST versioning strategy.
+Themes and renderers will need to be updated to handle the new `Outputs` container node and iterate over `Output` children. However, the rendering output should remain consistent, as the logical grouping of outputs is preserved. Currently there is coupling between the HTML site (the result of `myst start`) and the CLI. Version mismatches can result in outputs not being shown in older themes; we anticipate a future MEP that addresses this coupling/versioning issue.
 
 ## References
 
@@ -271,4 +186,3 @@ This MEP addresses requirements from:
 - [Generate MyST AST from cell execution #1633](https://github.com/jupyter-book/mystmd/issues/1633)
 - [Special characters are escaped in table cells #1555](https://github.com/jupyter-book/mystmd/issues/1555)
 - [Update theme to handle new AST structure](https://github.com/jupyter-book/mystmd/pull/1903)
-

--- a/meps/mep-0004.md
+++ b/meps/mep-0004.md
@@ -148,14 +148,6 @@ The `text/markdown` output may be parsed into native `children` nodes in native 
 
 ## Implementation Details
 
-### Parsing Output Content
-
-When output content is parsed (e.g., Markdown or LaTeX from MIME bundles), the resulting AST is stored in the `children` field of the corresponding `Output` node. This parsing happens during the build process, allowing the output AST to participate in:
-
-- Cross-reference resolution
-- Label generation
-- Citation processing
-- Other MyST transforms
 
 ### Backward Compatibility
 

--- a/meps/mep-0004.md
+++ b/meps/mep-0004.md
@@ -8,7 +8,7 @@ authors:
   - agoose77
   - rowanc1
 tags:
-  - Draft
+  - Active
 data:
   discussion: https://github.com/jupyter-book/mystmd/issues/1026
 ---

--- a/meps/mep-0004.md
+++ b/meps/mep-0004.md
@@ -27,7 +27,7 @@ This limitation prevents programmatic generation of content that integrates with
 
 ### Use Cases
 
-This enhancement enables several important use cases:
+This enhancement lays the foundation to enable several important use cases (it does not solve for those use-cases now, but is a required step):
 
 1. **Programmatic Content Generation**: Users can generate MyST Markdown from code cells, and this content can participate fully in the build process, including reference resolution.
 

--- a/meps/mep-0004.md
+++ b/meps/mep-0004.md
@@ -15,13 +15,13 @@ data:
 
 ## Summary
 
-We propose extending the MyST AST to represent individual code cell outputs as separate AST nodes. Previously, `Output` nodes could not represent AST trees for each output. With this change, the `Outputs` node has `Output` children with a 1:1 correspondence to `IOutput` bundles in Jupyter, enabling each output to carry its own AST subtree. This allows code cell output content (e.g., Markdown, LaTeX, tables) to be parsed and participate fully in MyST builds, including the ability to generate and consume reference labels.
+We propose extending the MyST AST with a new node type to represent individual code-cell outputs as separate AST nodes. In the existing schema, the `Output` node type represents a collection of outputs, and has a one-to-one correspondence with each code-cell. This structure does not naturally admit distinguishing between AST trees for each output, precluding the ability to consider code-cell outputs during subsequent transformations of the document. With this proposal, a new `Outputs` node replaces the `Output` node as a direct child of code-cells with a unist `Parent` container. This new node may contain several `Output` child nodes, each possessing an `IOutput` bundle returned by code-execution. The new AST structure enables each `Output` to carry its own AST subtree. Subsequent enhancements may build upon this proposal to process code-cell outputs and build derived ASTs, e.g. parsing Markdown or LaTeX outputs into MyST AST that may reference and be referenced by other content.
 
 ## Context
 
 ### Current Limitations
 
-Code-cells from Jupyter Notebooks can produce rich output like Markdown, LaTeX, and tables. Right now, these outputs are only rendered at display time, meaning that each static export and web build needs to interpret the MIME bundle outputs. As a result, the output content cannot participate in a MyST build, that is, the Markdown or LaTeX output cannot generate or consume referencing labels.
+Code-cells from Jupyter Notebooks can produce rich output like Markdown, LaTeX, and tables. Right now, each output is effectively treated as a <wiki:Black_Box>, which is only interpreted at export time (to PDF, web, etc.) such that static exports and web build are required to interpret the MIME bundle outputs. As a result, the output content does not participate in a MyST build i.e. the Markdown or LaTeX output cannot generate or consume referencing labels.
 
 This limitation prevents programmatic generation of content that integrates with the rest of the document. For example, if a code cell generates Markdown output containing a figure with a label, that label cannot be referenced from other parts of the document, and the figure cannot appear in cross-reference resolution.
 
@@ -270,3 +270,4 @@ This MEP addresses requirements from:
 - [Generate MyST AST from cell execution #1633](https://github.com/jupyter-book/mystmd/issues/1633)
 - [Special characters are escaped in table cells #1555](https://github.com/jupyter-book/mystmd/issues/1555)
 - [Update theme to handle new AST structure](https://github.com/jupyter-book/mystmd/pull/1903)
+

--- a/meps/mep-0004.md
+++ b/meps/mep-0004.md
@@ -1,0 +1,272 @@
+---
+label: MEP0004
+title: Per-Output AST Representation for Code Cell Outputs
+short_title: Per-Output AST
+description: Extend the MyST AST to represent individual code cell outputs as separate AST nodes, enabling output content to participate in MyST builds (e.g., generate and consume reference labels).
+date: 2025/12/04
+authors:
+  - agoose77
+  - rowanc1
+tags:
+  - Draft
+data:
+  discussion: https://github.com/jupyter-book/mystmd/issues/1026
+---
+
+## Summary
+
+We propose extending the MyST AST to represent individual code cell outputs as separate AST nodes. Previously, `Output` nodes could not represent AST trees for each output. With this change, the `Outputs` node has `Output` children with a 1:1 correspondence to `IOutput` bundles in Jupyter, enabling each output to carry its own AST subtree. This allows code cell output content (e.g., Markdown, LaTeX, tables) to be parsed and participate fully in MyST builds, including the ability to generate and consume reference labels.
+
+## Context
+
+### Current Limitations
+
+Code-cells from Jupyter Notebooks can produce rich output like Markdown, LaTeX, and tables. Right now, these outputs are only rendered at display time, meaning that each static export and web build needs to interpret the MIME bundle outputs. As a result, the output content cannot participate in a MyST build, that is, the Markdown or LaTeX output cannot generate or consume referencing labels.
+
+This limitation prevents programmatic generation of content that integrates with the rest of the document. For example, if a code cell generates Markdown output containing a figure with a label, that label cannot be referenced from other parts of the document, and the figure cannot appear in cross-reference resolution.
+
+### Use Cases
+
+This enhancement enables several important use cases:
+
+1. **Programmatic Content Generation**: Users can generate MyST Markdown from code cells, and this content can participate fully in the build process, including reference resolution.
+
+2. **Integrated Outputs**: Generated Markdown can define and consume reference targets that are visible to the rest of the project, enabling richer integration between computational content and documentation.
+
+3. **Executable Plugins Pattern**: Similar to executable plugins documentation for directives that can return MyST AST by printing to stdout, users should be able to do the same via `{code-cell}` directives and Jupyter Notebook cells. This would allow users to more flexibly generate MyST AST without requiring any kernel-specific libraries (since you'd just be using stdout).
+
+This proposal addresses the requirements described in [#1026](https://github.com/jupyter-book/mystmd/issues/1026), which tracks the need to associate AST subtrees with individual cell outputs.
+
+## Proposal
+
+### AST Structure Changes
+
+The MyST AST will be extended to support per-output AST representation through the following changes:
+
+**Previous Structure (Version 2):**
+
+```typescript
+type OutputV2 = {
+  type: 'output';
+  data?: any[]; // Array of IOutput bundles
+  visibility?: any;
+};
+```
+
+In this structure, a single `Output` node contained an **array** of output data bundles in the `data` field.
+
+**New Structure (Version 3):**
+
+```typescript
+type Output = {
+  type: 'output';
+  children: (FlowContent | ListContent | PhrasingContent)[];
+  jupyter_data: IOutput; // Single IOutput bundle from Jupyter Notebooks
+};
+
+type Outputs = {
+  type: 'outputs';
+  children: (Output | FlowContent | ListContent | PhrasingContent)[]; // Support placeholders in addition to outputs
+  visibility?: Visibility; // `show`, `hide`, or `remove`
+  scroll?: boolean;
+};
+```
+
+The key changes are:
+
+1. **`Output` nodes** now represent a single output with its own AST subtree in `children` and a single `jupyter_data` field (instead of an array).
+
+2. **`Outputs` node** is introduced as a container with `Output` children, where there is a 1:1 correspondence between `Output` children and `IOutput` bundles.
+
+3. Each `Output` child can have its own AST subtree, enabling per-output parsing and reference resolution.
+
+### Migration Strategy
+
+Existing identifiers for the `Output` / `Outputs` nodes are not modified, as these are considered "content". The migration path includes:
+
+**Upgrade (V2 → V3):**
+
+- Convert each `Output` node with `data` array into an `Outputs` node
+- Create one `Output` child per item in the original `data` array
+- Distribute the original `children` to the first output if there is only one output
+- Preserve placeholders and other special children
+
+**Downgrade (V3 → V2):**
+
+- Convert `Outputs` nodes back to `Output` nodes
+- Collect all `jupyter_data` fields from `Output` children into a `data` array
+- Merge all `Output` children AST subtrees into a single `children` array
+- Preserve identifiers and other metadata
+
+### Example Transformation
+
+**Before (V2):**
+
+```json
+{
+  "type": "output",
+  "data": [
+    { "output_type": "stream", "text": "Hello" },
+    { "output_type": "display_data", "data": { "text/markdown": "**Bold**" } }
+  ],
+  "children": [{ "type": "text", "value": "Shared content" }]
+}
+```
+
+**After (V3):**
+
+```json
+{
+  "type": "outputs",
+  "children": [
+    {
+      "type": "output",
+      "jupyter_data": { "output_type": "stream", "text": "Hello" },
+      "children": []
+    },
+    {
+      "type": "output",
+      "jupyter_data": { "output_type": "display_data", "data": { "text/markdown": "**Bold**" } },
+      "children": [
+        {
+          "type": "strong",
+          "children": [{ "type": "text", "value": "Bold" }]
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Examples
+
+### Markdown Output with References
+
+With this change, a code cell can generate Markdown output that defines and references labels:
+
+```python
+# Generate MyST content with a figure reference
+markdown_output = """
+Here is a reference to [](#fig:my-figure).
+
+:::{figure} images/plot.png
+:name: fig:my-figure
+
+My generated plot.
+:::
+"""
+
+from IPython.display import display
+display({
+  "text/markdown": markdown_output,
+}, raw=True)
+```
+
+The Markdown output can now be parsed and integrated into the document's reference resolution system.
+
+### Multiple Outputs with Individual ASTs
+
+A code cell that produces multiple outputs, each with its own parsed content:
+
+```python
+print("First output stream")
+display({"text/markdown": "**Second** output"}, raw=True)
+display({"text/latex": "$$E = mc^2$$"}, raw=True)
+```
+
+Each of these outputs will be represented as a separate `Output` node with its own AST subtree.
+
+## Implementation Details
+
+### Version Migration
+
+The version migration is handled through upgrade and downgrade functions that transform between V2 and V3 representations. The migration preserves:
+
+- Identifiers (`id`, `label`, `identifier`, `html_id`)
+- Target properties
+- Placeholder nodes
+- Visibility settings
+
+### Parsing Output Content
+
+When output content is parsed (e.g., Markdown or LaTeX from MIME bundles), the resulting AST is stored in the `children` field of the corresponding `Output` node. This parsing happens during the build process, allowing the output AST to participate in:
+
+- Cross-reference resolution
+- Label generation
+- Citation processing
+- Other MyST transforms
+
+### Backward Compatibility
+
+Existing content using V2 format will be automatically upgraded during processing. The downgrade path ensures that tools expecting V2 format can still work with V3 content when needed.
+
+## UX implications & migration
+
+### Benefits
+
+1. **Seamless Integration**: Code-generated content can now participate fully in MyST builds without special handling.
+
+2. **Better Cross-Referencing**: Generated figures, equations, and sections can be referenced from anywhere in the document.
+
+3. **Flexible Generation**: Users can generate MyST content programmatically using any Jupyter kernel without kernel-specific libraries.
+
+4. **Consistent Behavior**: Output parsing follows the same rules and capabilities as the rest of the document.
+
+### Migration Impact
+
+- **Automatic**: Existing documents will be automatically upgraded during processing. No manual migration is required.
+
+- **Transparent**: The change is primarily internal to the AST representation. Users working with parsed ASTs will need to handle the new structure, but the upgrade/downgrade functions provide a clear migration path.
+
+- **Non-Breaking**: For users writing MyST Markdown or notebooks, this change is transparent. The syntax and behavior remain the same.
+
+### Theme Considerations
+
+Themes and renderers will need to be updated to handle the new `Outputs` container node and iterate over `Output` children. However, the rendering output should remain consistent, as the logical grouping of outputs is preserved.
+
+## Definition of Done
+
+- Individual `IOutput` objects are represented in the AST as individual AST trees
+- Each `Output` node can carry its own AST subtree in `children`
+- `Outputs` node container has 1:1 correspondence between `Output` children and `IOutput` bundles
+- Version migration functions (upgrade/downgrade) correctly transform between V2 and V3
+- Generated Markdown in code cells can define and consume reference targets visible to the rest of the project
+- Generated Markdown appears correctly in PDF builds with proper cross-referencing
+- Multiple outputs from a single cell are correctly represented as separate `Output` nodes
+- Themes correctly render the new AST structure
+- In-browser execution via Thebe continues to work with the new structure
+
+## Questions or Objections
+
+### Kernel Support
+
+**Question**: Does this require all kernels to implement the display protocol?
+
+**Response**: All Jupyter kernels should implement the display protocol as part of the Jupyter message protocol. For kernels that don't support direct AST output, users can output Markdown or other MIME types that will be parsed into AST during the build process.
+
+### Performance Considerations
+
+**Question**: Will parsing outputs for every code cell impact build performance?
+
+**Response**: Output parsing will only occur when outputs contain parseable content (e.g., Markdown, LaTeX). Plain text or binary outputs will not trigger parsing. The performance impact should be minimal and only occur when the feature is actively used.
+
+### AST Versioning
+
+**Question**: How does this interact with other AST versioning?
+
+**Response**: This change introduces a new AST version (V3) for output nodes specifically. The migration functions ensure compatibility with existing V2 content. This is consistent with the MyST AST versioning strategy.
+
+## References
+
+- [Jupyter display protocol](https://ipython.readthedocs.io/en/stable/api/generated/IPython.display.html) - Standard way for kernels to output rich content
+- [MyST AST Specification](https://spec.mystmd.org) - Current AST structure and versioning
+- [GitHub Discussion on AST Output](https://github.com/jupyter-book/mystmd/issues/1026) - Original discussion thread
+
+## Related Issues and Pull Requests
+
+This MEP addresses requirements from:
+
+- [Improve granularity of execution outputs #1026](https://github.com/jupyter-book/mystmd/issues/1026)
+- [Generate MyST AST from cell execution #1633](https://github.com/jupyter-book/mystmd/issues/1633)
+- [Special characters are escaped in table cells #1555](https://github.com/jupyter-book/mystmd/issues/1555)
+- [Update theme to handle new AST structure](https://github.com/jupyter-book/mystmd/pull/1903)

--- a/meps/mep-0004.md
+++ b/meps/mep-0004.md
@@ -177,7 +177,23 @@ Existing content using V2 format can be automatically upgraded during processing
 
 ### Theme Considerations
 
-Themes and renderers will need to be updated to handle the new `Outputs` container node and iterate over `Output` children. However, the rendering output should remain consistent, as the logical grouping of outputs is preserved. Currently there is coupling between the HTML site (the result of `myst start`) and the CLI. Version mismatches can result in outputs not being shown in older themes; we anticipate a future MEP that addresses this coupling/versioning issue.
+As a direct consequence of this MEP, themes and renderers will need to be updated to handle the new `Outputs` container node and iterate over `Output` children. However, there are several ways that AST renderers such as web themes and templates can pull in incompatible ASTs:
+
+- New AST renderer provided with old AST content
+- Dynamic loading of new AST in old AST renderers (web only)
+- Dynamic loading of old AST in new AST renderers (web only)
+
+#### Content-Renderer Separation
+
+The MyST Document Engine enforces a strong separation between the MyST AST production engine (the MyST Document Engine itself) and the MyST AST rendering engine (e.g. MyST Theme for web applications). This separation is typically invisible, but it is entirely possible (and indeed desired) to perform the project build and project rendering steps at different times. For example, one may produce AST and push it to a CDN, where a MyST Theme application can render it.
+
+Due to the separation of the content rendering and the content generation, it is important to ensure that deployed AST rendering applications are prevented from attempting to render projects with unsupported AST versions. Whilst there is tooling to perform bidirectional AST migrations, these are not widely deployed in existing web themes. As such, users deploying MyST rendering engines must take care to anticipate AST mismatches, and perform AST migration steps themselves.
+
+Although typical usage of the MyST Document Engine as a static site generator hides this separation, the existing lack of constraint between the MyST Theme and MyST Document Engine versions can result in users encountering incompatible versions at build time. We anticipate a future MEP that attempts to address this UX problem.
+
+#### Dynamic loading of AST
+
+Outside of deploying AST renderers in a CDN context, it is also possible for MyST Themes to pull in incompatible AST via the external cross-reference (xref) mechanism. This may affect users who build sites with `myst build --site` and deploy them to static web servers like GitHub Pages. Sites that use external xrefs support dynamic fetching of AST, which happens at reading time, _not at page build time_. This means that xrefs may pull in incompatible (future or past) versions of the AST that may fail to render properly. Future work may be done to address AST upgrading and/or AST downgrading in these contexts.
 
 ## References
 

--- a/meps/mep-0004.md
+++ b/meps/mep-0004.md
@@ -159,6 +159,10 @@ When output content is parsed (e.g., Markdown or LaTeX from MIME bundles), the r
 
 ### Backward Compatibility
 
+:::{warning}
+Upgrading from V2 to V3 is a lossy process if the number of outputs is greater than one. It is not possible to exactly determine from a flat list of outputs which AST node correlates to which IOutput object. As such, we choose to drop them.
+:::
+
 Existing content using V2 format can be automatically upgraded during processing (e.g. [#2551](https://github.com/jupyter-book/mystmd/pull/2551)). The downgrade path ensures that tools expecting V2 format can still work with V3 content when needed.
 
 ## UX implications & migration

--- a/meps/mep-0004.md
+++ b/meps/mep-0004.md
@@ -160,7 +160,7 @@ When output content is parsed (e.g., Markdown or LaTeX from MIME bundles), the r
 ### Backward Compatibility
 
 :::{warning}
-Upgrading from V2 to V3 is a lossy process if the number of outputs is greater than one. It is not possible to exactly determine from a flat list of outputs which AST node correlates to which IOutput object. As such, we choose to drop them.
+Upgrading from V2 to V3 is a lossy process if the number of outputs is greater than one. It is not possible to exactly determine from a flat list of outputs which AST node correlates to which `IOutput` object. As such, we choose to drop them.
 :::
 
 Existing content using V2 format can be automatically upgraded during processing (e.g. [#2551](https://github.com/jupyter-book/mystmd/pull/2551)). The downgrade path ensures that tools expecting V2 format can still work with V3 content when needed.

--- a/myst.yml
+++ b/myst.yml
@@ -22,6 +22,8 @@ project:
     MEP: MyST Enhancement Proposal
     MyST: Markedly Structured Text
     PR: Pull Request
+    AST: Abstract Syntax Tree
+    CLI: Command Line Interface
   subject: MyST Enhancement Proposals
   venue:
     title: Project Jupyter


### PR DESCRIPTION
Extend the MyST AST to represent individual code cell outputs as separate AST nodes, enabling output content to participate in MyST builds (e.g., generate and consume reference labels).

[![Preview on MyST Sandbox](https://img.shields.io/badge/Preview%20on%20MyST%20Sandbox-gray?style=for-the-badge&link=https://mystmd.org/sandbox?url=https://github.com/jupyter-book/myst-enhancement-proposals/blob/mep/outputs/meps/mep-0004.md?raw=true)](https://mystmd.org/sandbox?url=https://github.com/jupyter-book/myst-enhancement-proposals/blob/mep/outputs/meps/mep-0004.md?raw=true)

## Authors

- @agoose77
- @rowanc1

## Issue

- https://github.com/jupyter-book/mystmd/issues/1026
